### PR TITLE
feat: add Dump option for easy debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,11 @@ r, err := requests.Get("http://example.com?a=1&b=2",
 if err != nil { /* ... */ }
 // URL: http://example.com?a=1&b=2&c=3
 ```
+
+### Dump outgoing client request and response
+
+```go
+var reqDump, respDump string
+r, err := requests.Get("http://example.com", 
+            requests.Dump(&request, &respDump))
+```

--- a/options.go
+++ b/options.go
@@ -30,6 +30,9 @@ type httpOptions struct {
 	Timeout time.Duration
 
 	DisableKeepAlives bool
+	// dump
+	DumpRequestOut *string
+	DumpResponse   *string
 }
 
 // Option is the functional option type.
@@ -204,6 +207,19 @@ func Timeout(timeout time.Duration) Option {
 func DisableKeepAlives() Option {
 	return func(opts *httpOptions) {
 		opts.DisableKeepAlives = true
+	}
+}
+
+// Dump dumps outgoing client request and response to the corresponding
+// input param (req or resp) if not nil.
+//
+// Refer:
+// - https://pkg.go.dev/net/http/httputil#DumpRequestOut
+// - https://pkg.go.dev/net/http/httputil#DumpResponse
+func Dump(req, resp *string) Option {
+	return func(opts *httpOptions) {
+		opts.DumpRequestOut = req
+		opts.DumpResponse = resp
 	}
 }
 

--- a/request.go
+++ b/request.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"strings"
 
@@ -100,12 +101,29 @@ func request(method, urlStr string, options ...Option) (*Response, error) {
 		Transport:     transport,
 	}
 
+	if opts.DumpRequestOut != nil {
+		reqDump, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		*opts.DumpRequestOut = string(reqDump)
+	}
+
 	// If the returned error is nil, the Response will contain
 	// a non-nil Body which the user is expected to close.
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
+
+	if opts.DumpResponse != nil {
+		respDump, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		*opts.DumpResponse = string(respDump)
+	}
+
 	return newResponse(resp, opts)
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -339,6 +339,7 @@ func TestPostJson(t *testing.T) {
 
 	var jsonResp EchoResponse
 	var textResp string
+	var reqDump, respDump string
 	type args struct {
 		url     string
 		options []Option
@@ -363,6 +364,7 @@ func TestPostJson(t *testing.T) {
 					JSON(&EchoRequest{ID: 1, Name: "Hello"}),
 					ToJSON(&jsonResp),
 					ToText(&textResp),
+					Dump(&reqDump, &respDump),
 				},
 				timeout: 5 * time.Second,
 			},
@@ -386,6 +388,8 @@ func TestPostJson(t *testing.T) {
 				t.Logf("body: %+v", got.Text())
 				t.Logf("body(text): %+v", textResp)
 				t.Logf("body(json): %+v", jsonResp)
+				t.Logf("Request(dump): %s", reqDump)
+				t.Logf("Response(dump): %s", respDump)
 			} else {
 				t.Logf("Get failed: %v", err)
 			}

--- a/request_test.go
+++ b/request_test.go
@@ -388,8 +388,8 @@ func TestPostJson(t *testing.T) {
 				t.Logf("body: %+v", got.Text())
 				t.Logf("body(text): %+v", textResp)
 				t.Logf("body(json): %+v", jsonResp)
-				t.Logf("Request(dump): %s", reqDump)
-				t.Logf("Response(dump): %s", respDump)
+				t.Logf("Request(dump):\n%s", reqDump)
+				t.Logf("Response(dump):\n%s", respDump)
 			} else {
 				t.Logf("Get failed: %v", err)
 			}


### PR DESCRIPTION
- close #25 

Dump:
```
Request(dump): 
        POST /?param1=value1&param2=value2 HTTP/1.1
        Host: 127.0.0.1:64197
        User-Agent: Go-http-client/1.1
        Content-Length: 23
        Content-Type: application/json
        Header1: value1
        Header2: value2
        Accept-Encoding: gzip

        {"ID":1,"Name":"Hello"}

Response(dump): 
        HTTP/1.1 200 OK
        Content-Length: 28
        Content-Type: text/plain; charset=utf-8
        Date: Fri, 25 Aug 2023 02:33:53 GMT

        {"ID":1,"Name":"echo Hello"}
```