### PR TITLE
interceptor: support interceptor option to intercept each HTTP request/response

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,28 +3,51 @@ package requests
 import (
 	"context"
 	"net/http"
+	"net/http/httputil"
 )
 
 // Do is called by Interceptor to complete HTTP requests.
-type Do func(ctx context.Context, r *http.Request) (*http.Response, error)
+type Do func(ctx context.Context, r *Request) (*Response, error)
 
 // Interceptor provides a hook to intercept the execution of an HTTP request
 // invocation. When an interceptor(s) is set, requests delegates all HTTP
 // client invocations to the interceptor, and it is the responsibility of the
 // interceptor to call do to complete the processing of the HTTP request.
-type Interceptor func(ctx context.Context, r *http.Request, do Do) (*http.Response, error)
+type Interceptor func(ctx context.Context, r *Request, do Do) (*Response, error)
 
 type Client struct {
 	*http.Client
 }
 
 // Do sends the HTTP request and returns after response is received.
-func (c *Client) Do(ctx context.Context, r *http.Request) (*http.Response, error) {
+func (c *Client) Do(ctx context.Context, r *Request) (*Response, error) {
 	if env.interceptor != nil {
-		do := func(ctx context.Context, r *http.Request) (*http.Response, error) {
-			return c.Client.Do(r)
-		}
-		return env.interceptor(ctx, r, do)
+		return env.interceptor(ctx, r, c.do)
 	}
-	return c.Client.Do(r)
+	return c.do(ctx, r)
+}
+
+func (c *Client) do(ctx context.Context, r *Request) (*Response, error) {
+	if r.opts.DumpRequestOut != nil {
+		reqDump, err := httputil.DumpRequestOut(r.Request, true)
+		if err != nil {
+			return nil, err
+		}
+		*r.opts.DumpRequestOut = string(reqDump)
+	}
+	// If the returned error is nil, the Response will contain
+	// a non-nil Body which the user is expected to close.
+	resp, err := c.Client.Do(r.Request)
+	if err != nil {
+		return nil, err
+	}
+	if r.opts.DumpResponse != nil {
+		respDump, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		*r.opts.DumpResponse = string(respDump)
+	}
+
+	return newResponse(resp, r.opts)
 }

--- a/client.go
+++ b/client.go
@@ -1,0 +1,30 @@
+package requests
+
+import (
+	"context"
+	"net/http"
+)
+
+// Do is called by Interceptor to complete HTTP requests.
+type Do func(ctx context.Context, r *http.Request) (*http.Response, error)
+
+// Interceptor provides a hook to intercept the execution of an HTTP request
+// invocation. When an interceptor(s) is set, requests delegates all HTTP
+// client invocations to the interceptor, and it is the responsibility of the
+// interceptor to call do to complete the processing of the HTTP request.
+type Interceptor func(ctx context.Context, r *http.Request, do Do) (*http.Response, error)
+
+type Client struct {
+	*http.Client
+}
+
+// Do sends the HTTP request and returns after response is received.
+func (c *Client) Do(ctx context.Context, r *http.Request) (*http.Response, error) {
+	if env.interceptor != nil {
+		do := func(ctx context.Context, r *http.Request) (*http.Response, error) {
+			return c.Client.Do(r)
+		}
+		return env.interceptor(ctx, r, do)
+	}
+	return c.Client.Do(r)
+}

--- a/env.go
+++ b/env.go
@@ -1,23 +1,29 @@
 package requests
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"time"
 )
 
 type environment struct {
-	Timeout          time.Duration
-	DefaultTransport *http.Transport
+	timeout time.Duration
+	// transport establishes network connections as needed and
+	// caches them for reuse by subsequent calls. It uses HTTP proxies as
+	// directed by the environment variables HTTP_PROXY, HTTPS_PROXY and
+	// NO_PROXY (or the lowercase versions thereof).
+	transport   *http.Transport
+	interceptor Interceptor
 }
 
 var env environment
 
 func init() {
-	env.Timeout = 60 * time.Second // default timeout
+	env.timeout = 60 * time.Second // default timeout
 	// DefaultTransport
 	// refer: https://github.com/golang/go/blob/c333d07ebe9268efc3cf4bd68319d65818c75966/src/net/http/transport.go#L42
-	env.DefaultTransport = &http.Transport{
+	env.transport = &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
@@ -34,5 +40,35 @@ func init() {
 // SetEnvTimeout sets the default timeout for each HTTP request at
 // the environment level.
 func SetEnvTimeout(timeout time.Duration) {
-	env.Timeout = timeout
+	env.timeout = timeout
+}
+
+// WithInterceptor specifies the interceptor for each HTTP request.
+func WithInterceptor(interceptors ...Interceptor) {
+	// Prepend env.interceptor to the chaining interceptors if it exists, since
+	// env.interceptor will be executed before any other chained interceptors.
+	if env.interceptor != nil {
+		interceptors = append([]Interceptor{env.interceptor}, interceptors...)
+	}
+	var chainedInt Interceptor
+	if len(interceptors) == 0 {
+		chainedInt = nil
+	} else if len(interceptors) == 1 {
+		chainedInt = interceptors[0]
+	} else {
+		chainedInt = func(ctx context.Context, r *http.Request, do Do) (*http.Response, error) {
+			return interceptors[0](ctx, r, getChainDo(interceptors, 0, do))
+		}
+	}
+	env.interceptor = chainedInt
+}
+
+// getChainDo recursively generates the chained do.
+func getChainDo(interceptors []Interceptor, curr int, finalDo Do) Do {
+	if curr == len(interceptors)-1 {
+		return finalDo
+	}
+	return func(ctx context.Context, r *http.Request) (*http.Response, error) {
+		return interceptors[curr+1](ctx, r, getChainDo(interceptors, curr+1, finalDo))
+	}
 }

--- a/env.go
+++ b/env.go
@@ -56,7 +56,7 @@ func WithInterceptor(interceptors ...Interceptor) {
 	} else if len(interceptors) == 1 {
 		chainedInt = interceptors[0]
 	} else {
-		chainedInt = func(ctx context.Context, r *http.Request, do Do) (*http.Response, error) {
+		chainedInt = func(ctx context.Context, r *Request, do Do) (*Response, error) {
 			return interceptors[0](ctx, r, getChainDo(interceptors, 0, do))
 		}
 	}
@@ -68,7 +68,7 @@ func getChainDo(interceptors []Interceptor, curr int, finalDo Do) Do {
 	if curr == len(interceptors)-1 {
 		return finalDo
 	}
-	return func(ctx context.Context, r *http.Request) (*http.Response, error) {
+	return func(ctx context.Context, r *Request) (*Response, error) {
 		return interceptors[curr+1](ctx, r, getChainDo(interceptors, curr+1, finalDo))
 	}
 }

--- a/options.go
+++ b/options.go
@@ -230,7 +230,7 @@ func newDefaultOptions() *httpOptions {
 		Params:  map[string]string{},
 		Form:    nil,
 		JSON:    nil,
-		Timeout: env.Timeout,
+		Timeout: env.timeout,
 	}
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -17,16 +17,16 @@ import (
 	"github.com/pkg/errors"
 )
 
-func logInterceptor(ctx context.Context, r *http.Request, do Do) (*http.Response, error) {
+func logInterceptor(ctx context.Context, r *Request, do Do) (*Response, error) {
 	log.Printf("method: %s", r.Method)
 	return do(ctx, r)
 }
 
-func metricInterceptor(ctx context.Context, r *http.Request, do Do) (*http.Response, error) {
+func metricInterceptor(ctx context.Context, r *Request, do Do) (*Response, error) {
 	log.Printf("method: %s, url: %s", r.Method, r.URL)
 	resp, err := do(ctx, r)
 	if err == nil {
-		log.Printf("method: %s, response.status: %s", r.Method, resp.Status)
+		log.Printf("method: %s, response.status: %s", r.Method, resp.StatusText())
 	}
 	return resp, err
 }

--- a/request_test.go
+++ b/request_test.go
@@ -2,9 +2,11 @@ package requests
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,6 +16,24 @@ import (
 
 	"github.com/pkg/errors"
 )
+
+func logInterceptor(ctx context.Context, r *http.Request, do Do) (*http.Response, error) {
+	log.Printf("method: %s", r.Method)
+	return do(ctx, r)
+}
+
+func metricInterceptor(ctx context.Context, r *http.Request, do Do) (*http.Response, error) {
+	log.Printf("method: %s, url: %s", r.Method, r.URL)
+	resp, err := do(ctx, r)
+	if err == nil {
+		log.Printf("method: %s, response.status: %s", r.Method, resp.Status)
+	}
+	return resp, err
+}
+
+func init() {
+	WithInterceptor(logInterceptor, metricInterceptor)
+}
 
 func TestGet(t *testing.T) {
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/response.go
+++ b/response.go
@@ -53,14 +53,23 @@ func (r *Response) readAndCloseBody() error {
 }
 
 // StatusCode returns status code of HTTP response.
+//
+// NOTE: It will return -1 if response is nil.
 func (r *Response) StatusCode() int {
-	if r.resp == nil {
-		return http.StatusServiceUnavailable
+	if r == nil || r.resp == nil {
+		// return special status code -1 which is not registered with IANA.
+		return -1
 	}
 	return r.resp.StatusCode
 }
 
-// Bytes parses the HTTP response body as []byte.
+// StatusText returns a text for the HTTP status code. It returns the empty
+// string if the code is unknown.
+func (r *Response) StatusText(code int) string {
+	return http.StatusText(r.StatusCode())
+}
+
+// Bytes returns the HTTP response body as []byte.
 func (r *Response) Bytes() []byte {
 	return r.body
 }

--- a/response.go
+++ b/response.go
@@ -7,19 +7,19 @@ import (
 	"net/http"
 )
 
-// Response is a wrapper of HTTP response.
+// Response is a wrapper of http.Response.
 type Response struct {
-	resp *http.Response
-	body []byte // auto filled from resp.Body
+	*http.Response
+	body []byte // auto filled from Response.Body
 }
 
-// newResponse reads and closes resp.Body. Then check the HTTP status
+// newResponse reads and closes Response.Body. Then check the HTTP status
 // in Response.StatusCode. It will return an error with status and text
 // body embedded if status code is not 2xx, and none-nil response is also
 // returned.
 func newResponse(resp *http.Response, opts *httpOptions) (*Response, error) {
 	r := &Response{
-		resp: resp,
+		Response: resp,
 	}
 	if err := r.readAndCloseBody(); err != nil {
 		return nil, err
@@ -43,9 +43,9 @@ func newResponse(resp *http.Response, opts *httpOptions) (*Response, error) {
 
 // readAndCloseBody drains all the HTTP response body stream and then closes it.
 func (r *Response) readAndCloseBody() error {
-	defer r.resp.Body.Close()
+	defer r.Response.Body.Close()
 	var err error
-	r.body, err = io.ReadAll(r.resp.Body)
+	r.body, err = io.ReadAll(r.Response.Body)
 	if err != nil {
 		return err
 	}
@@ -54,19 +54,28 @@ func (r *Response) readAndCloseBody() error {
 
 // StatusCode returns status code of HTTP response.
 //
-// NOTE: It will return -1 if response is nil.
+// NOTE: It returns -1 if response is nil.
 func (r *Response) StatusCode() int {
-	if r == nil || r.resp == nil {
+	if r == nil || r.Response == nil {
 		// return special status code -1 which is not registered with IANA.
 		return -1
 	}
-	return r.resp.StatusCode
+	return r.Response.StatusCode
 }
 
-// StatusText returns a text for the HTTP status code. It returns the empty
-// string if the code is unknown.
-func (r *Response) StatusText(code int) string {
-	return http.StatusText(r.StatusCode())
+// StatusText returns a text for the HTTP status code.
+//
+// NOTE:
+//   - It returns "Response is nil" if response is nil.
+//   - It returns the empty string if the code is unknown.
+//
+// e.g. "OK"
+func (r *Response) StatusText() string {
+	if r == nil || r.Response == nil {
+		// return special status code -1 which is not registered with IANA.
+		return "Response is nil"
+	}
+	return r.Response.Status
 }
 
 // Bytes returns the HTTP response body as []byte.
@@ -86,24 +95,24 @@ func (r *Response) JSON(v any) error {
 
 // Method returns the HTTP request method.
 func (r *Response) Method() string {
-	return r.resp.Request.Method
+	return r.Response.Request.Method
 }
 
 // URL returns the HTTP request URL string.
 func (r *Response) URL() string {
-	return r.resp.Request.URL.String()
+	return r.Response.Request.URL.String()
 }
 
 // Headers maps header keys to values. If the response had multiple headers
 // with the same key, they may be concatenated, with comma delimiters.
 func (r *Response) Headers() http.Header {
-	return r.resp.Header
+	return r.Response.Header
 }
 
 // Cookies parses and returns the cookies set in the Set-Cookie headers.
 func (r *Response) Cookies() map[string]*http.Cookie {
 	m := make(map[string]*http.Cookie)
-	for _, c := range r.resp.Cookies() {
+	for _, c := range r.Response.Cookies() {
 		m[c.Name] = c
 	}
 	return m


### PR DESCRIPTION
- [x] close #30 
- [x] close #31
- [x] add new `Request` struct to encapsulate `http.Request`
- [x] use requests custom defiend `Request` and `Response` to change interceptor prototype to: 
    ```go
    type Interceptor func(ctx context.Context, r *Request, do Do) (*Response, error)
    ```

## Example
```go
func logInterceptor(ctx context.Context, r *Request, do Do) (*Response, error) {
	log.Printf("method: %s", r.Method)
	return do(ctx, r)
}

func metricInterceptor(ctx context.Context, r *Request, do Do) (*Response, error) {
	log.Printf("method: %s, url: %s", r.Method, r.URL)
	resp, err := do(ctx, r)
	if err == nil {
		log.Printf("method: %s, response.status: %s", r.Method, resp.StatusText())
	}
	return resp, err
}

func init() {
	WithInterceptor(logInterceptor, metricInterceptor)
}
```